### PR TITLE
Bjornm/more accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Then, open http://localhost:7777
 
 ### Safari note
 
-2019-09-11: A memory leak in Safari makes the browser tab crash after 50 test runs or so. To avoid it, reduce number of test runs to 1. If this doesn't help, reduce the test duration to 100 seconds or
-even lower, see `DEFAULT_RENDER_SECONDS` in `WebAudioBenchApplication.js`.
+2019-09-11: A memory leak in Safari makes the browser tab crash after 50 test runs or so. To avoid it, reduce number of test runs. If this doesn't help, reduce the test duration too.
+
+Also note that Safari time resolution is limited to 1ms, so the default test duration is set to 5x longer than on other browsers.
 
 # Developing
 
@@ -56,10 +57,9 @@ example, we can provide different `knee`-values and see how this affects perform
 
 After having written your test, add it to the list of tests in `WebAudioBenchApplication.getTestList()`.
 
-In order to get fast test runs while not measuring too short time periods, all tests have been tuned to take approximately 500 ms on a MacBook Pro 2017 (3,1 GHz Intel Core i7) when running in Chrome 78. When adding your
+In order to get fast test runs while not measuring too short time periods, all tests have been tuned to take approximately 50 ms on a MacBook Pro 2017 (3,1 GHz Intel Core i7) when running in Chrome 78. When adding your
 own tests, try to make them run roughly as long. You can tune the test duration by setting `numNodes` in the `Test` constructor, which will indicate how many
-nodes you intend to test on in parallel. The total duration of your test will then be divided by this number. You can also tune the test duration by reducing the length of the test audio signal, see
-`DEFAULT_RENDER_SECONDS`.
+nodes you intend to test on in parallel. The total duration of your test will then be divided by this number.
 
 ## Contributing
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -62,6 +62,10 @@ h1 {
     width: 250px;
 }
 
+.run-settings .duration input {
+    width: 250px;
+}
+
 .run-settings .tests-selection select {
     width: 250px;
     height: 250px;

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 <h1>Web Audio Bench</h1>
 
 <p>This page contains a series of web audio benchmark tests. The tests are run in an OfflineAudioContext, where an AudioBufferSourceNode is used as baseline to feed data into the test.
-    To get more accurate results, each test is run multiple times and the median duration is chosen. The results are given in microseconds per second of processed audio data and node, so lower is
+    To get more accurate results, each test is run multiple times and the min duration is chosen (<a href="https://lemire.me/blog/2018/01/16/microbenchmarking-calls-for-idealized-conditions/" target="_blank">here's why</a>). The results are given in microseconds per second of processed audio data and node, so lower is
     faster. A value of 1000000 means realtime processing speed.</p>
 
 <p>For accurate results:</p>
@@ -29,6 +29,7 @@
     <li>Close ALL other apps and browser tabs.</li>
     <li>Verify in Activity Monitor / Task Manager that the computer is idle.</li>
     <li>Use an incognito window (disables extensions)</li>
+    <li>Firefox: set privacy.reduceTimerPrecision to false in about:config</li>
 </ul>
 
 <div class="mid-section">
@@ -41,7 +42,11 @@
             </div>
             <div class="control runs">
                 <label>Test runs:</label>
-                <input type="text" class="input-basic" value="5"/>
+                <input type="text" class="input-basic" value="500"/>
+            </div>
+            <div class="control duration">
+                <label>Seconds:</label>
+                <input type="text" class="input-basic" value="20"/>
             </div>
             <div class="control actions">
                 <label></label>

--- a/js/Test.js
+++ b/js/Test.js
@@ -71,6 +71,7 @@ class Test {
         source.loop = true;
         source.loopStart = 0;
         source.loopEnd = 1;
+        source.playbackRate.value = 0.9;
         source.start(0);
 
         let last = this.buildGraph(ctx, source);

--- a/js/Test.js
+++ b/js/Test.js
@@ -85,12 +85,12 @@ class Test {
       let startTime;
       // cooling period
       setTimeout(() => {
-        startTime = new Date().getTime();
+        startTime = window.performance.now();
         ctx.startRendering();
-      }, 500);
+      }, 10);
 
-      ctx.oncomplete = (_) => {
-        const endTime = new Date().getTime();
+      ctx.oncomplete = (event) => {
+        const endTime = event.timeStamp;
         const duration = (endTime - startTime) / 1000;
         resolve(duration);
       };

--- a/js/Test.js
+++ b/js/Test.js
@@ -60,7 +60,9 @@ class Test {
       const ctx = new (window.OfflineAudioContext || window.webkitOfflineAudioContext)(1, sampleRate * duration, sampleRate);
 
       try {
-        // we use an AudioBufferSourceNode as baseline, it's cheap at playbackRate 1.
+        // we use an AudioBufferSourceNode as baseline.
+        // We set playbackRate to something other than 1 so the node needs to do a bit of work.
+        // This gives more stable results than having playbackRate of 1.
         const source = ctx.createBufferSource();
         const buffer = ctx.createBuffer(1, sampleRate, sampleRate);
         const chan = buffer.getChannelData(0);

--- a/js/WebAudioBenchApplication.js
+++ b/js/WebAudioBenchApplication.js
@@ -130,7 +130,7 @@ class WebAudioBenchApplication {
   runTests(testNames, testRuns) {
     const baselineRuns = testRuns * 2;
     const tests = this.getTestList();
-    const baselineTest = new Test('Baseline', 1);
+    const baselineTest = new Test('Baseline', 1, 4);
     let baseline = 0;
     let chain = this.runTest(baselineTest, baselineRuns).then((durations) => {
       baseline = Math.min(...durations);

--- a/js/WebAudioBenchApplication.js
+++ b/js/WebAudioBenchApplication.js
@@ -211,16 +211,16 @@ class WebAudioBenchApplication {
     const q3 = durations[Math.floor(durations.length * 0.75)];
     const max = durations[durations.length - 1];
 
-    console.log('median ' + median + ' (' + durations + ')');
+    console.log('min ' + min + ' (' + durations + ')');
 
-    this.testResults[name] = median;
+    this.testResults[name] = min;
 
     const showDetails = durations.length >= 5;
     this.outputResult(name, min, q1, median, q3, max, showDetails);
   }
 
   outputResult(name, min, q1, median, q3, max, showDetails) {
-    const cells = [name, "" + Math.round(median)];
+    const cells = [name, "" + Math.round(min)];
     if (showDetails) {
       [min, q1, median, q3, max].map(v => "" + Math.round(v)).forEach(v => cells.push(v));
     }


### PR DESCRIPTION
Made the tests more accurate by 
- using window.performance.now()
- using the fastest run as truth
- running hundreds of test runs of short duration to dodge javascript garbage collection
- made the baseline test heavier to be easier to measure
Please see commits one by one.
