### PR TITLE
Add mean/stddev and some query strings and logs

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,8 @@
                 <th>MEDIAN</th>
                 <th>Q3</th>
                 <th>MAX</th>
+	        <th>MEAN</th>
+	        <th>STDDEV</th>
             </tr>
         </table>
     </div>

--- a/js/WebAudioBenchApplication.js
+++ b/js/WebAudioBenchApplication.js
@@ -96,7 +96,6 @@ class WebAudioBenchApplication {
       new AudioBufferSourceTest(1.0, 20),
       new AudioBufferSourceTest(0.9, 8),
       new OscillatorTest(),
-      new OscillatorFrequencyTest(880),
       new GainTest('default', '', 'default'),
       new GainTest(1.0, '', '1.0'),
       new GainTest(0.9, '', '0.9'),

--- a/js/WebAudioBenchApplication.js
+++ b/js/WebAudioBenchApplication.js
@@ -46,6 +46,15 @@ class WebAudioBenchApplication {
       durationInputElement.value = 20;
     }
 
+    // Update the runs and duration from the URL, if given
+    let urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has('runs')) {
+      runsInputElement.value = urlParams.get('runs');
+    }
+    if (urlParams.has('sec')) {
+      durationInputElement.value = urlParams.get('sec');
+    }
+
     this.resultsTable = document.querySelector('.results-table');
     this.runButton = document.querySelector('.run-button');
     this.runButton.addEventListener('mousedown', () => {

--- a/js/WebAudioBenchApplication.js
+++ b/js/WebAudioBenchApplication.js
@@ -244,6 +244,7 @@ class WebAudioBenchApplication {
     const max = durations[durations.length - 1];
 
     console.log('Test ' + name);
+    console.log(`Stats: (${min},${min},{$q1},${median},${q3},${max},${mean},${stddev})`);
     console.log('min ' + min + ' (' + durations + ')');
     console.log('mean = ', mean);
     console.log('stddev = ', stddev);

--- a/js/WebAudioBenchApplication.js
+++ b/js/WebAudioBenchApplication.js
@@ -54,6 +54,13 @@ class WebAudioBenchApplication {
     if (urlParams.has('sec')) {
       durationInputElement.value = urlParams.get('sec');
     }
+    // Verbosity level of console logs.  Higher means more logs. 0
+    // means the least.
+    if (urlParams.has('verbosity')) {
+      this.verbosity = urlParams.get('verbosity');
+    } else {
+      this.verbosity = 99;
+    }
 
     this.resultsTable = document.querySelector('.results-table');
     this.runButton = document.querySelector('.run-button');
@@ -195,7 +202,9 @@ class WebAudioBenchApplication {
         chain = chain.then((_) => test.run(renderSeconds));
       }
       chain = chain.then((duration) => {
-        console.log('took ' + Math.round(duration * 1000) + ' ms');
+        if (this.verbosity >= 99) {
+          console.log('took ' + Math.round(duration * 1000) + ' ms');
+	}
         duration /= renderSeconds;
         durations.push(duration);
         return durations;
@@ -225,9 +234,6 @@ class WebAudioBenchApplication {
     }
     stddev = Math.sqrt(stddev / (durations.length - 1));
 
-    console.log('mean = ', mean);
-    console.log('stddev = ', stddev);
-
     durations = durations.map((d) => Math.round(d * 1000 * 1000));
     durations.sort((a, b) => a - b);
 
@@ -237,7 +243,10 @@ class WebAudioBenchApplication {
     const q3 = durations[Math.floor(durations.length * 0.75)];
     const max = durations[durations.length - 1];
 
+    console.log('Test ' + name);
     console.log('min ' + min + ' (' + durations + ')');
+    console.log('mean = ', mean);
+    console.log('stddev = ', stddev);
 
     this.testResults[name] = min;
 

--- a/js/WebAudioBenchApplication.js
+++ b/js/WebAudioBenchApplication.js
@@ -96,6 +96,7 @@ class WebAudioBenchApplication {
       new AudioBufferSourceTest(1.0, 20),
       new AudioBufferSourceTest(0.9, 8),
       new OscillatorTest(),
+      new OscillatorFrequencyTest(880),
       new GainTest('default', '', 'default'),
       new GainTest(1.0, '', '1.0'),
       new GainTest(0.9, '', '0.9'),
@@ -202,6 +203,23 @@ class WebAudioBenchApplication {
   }
 
   storeResult(name, durations) {
+    let mean = 0;
+    let stddev = 0;
+
+    for (let k = 0; k < durations.length; ++k) {
+	mean += durations[k];
+    }
+    mean = mean / durations.length;
+
+    for (let k = 0; k < durations.length; ++k) {
+      let diff = durations[k] - mean;
+      stddev += diff * diff;
+    }
+    stddev = Math.sqrt(stddev / (durations.length - 1));
+
+    console.log('mean = ', mean);
+    console.log('stddev = ', stddev);
+
     durations = durations.map((d) => Math.round(d * 1000 * 1000));
     durations.sort((a, b) => a - b);
 
@@ -216,13 +234,14 @@ class WebAudioBenchApplication {
     this.testResults[name] = min;
 
     const showDetails = durations.length >= 5;
-    this.outputResult(name, min, q1, median, q3, max, showDetails);
+    this.outputResult(name, min, q1, median, q3, max, mean, stddev, showDetails);
   }
 
-  outputResult(name, min, q1, median, q3, max, showDetails) {
+  outputResult(name, min, q1, median, q3, max, mean, stddev, showDetails) {
     const cells = [name, "" + Math.round(min)];
     if (showDetails) {
-      [min, q1, median, q3, max].map(v => "" + Math.round(v)).forEach(v => cells.push(v));
+	[min, q1, median, q3, max].map(v => "" + Math.round(v)).forEach(v => cells.push(v));
+	[mean, stddev].map(v => "" + Math.round(v*1000*1000*100)/100).forEach(v => cells.push(v));
     }
     this.outputRow(cells);
   }


### PR DESCRIPTION
A couple of things here that I've been using on my own fork.  I was wondering if you'd be interested in taking these changes:

- Add mean/stddev calculation. Useful for statistical testing to see if optimizations are making significant changes
- Add query string
    - verbosity: Controls how much output is set to the console. 0 means print just the test name, stats, and raw data, more or less. Non-zero (or not specified) produces current behavior
    - runs: specify the number of runs to use
    - sec: specify number fo seconds
- Log a bit more stuff
    - Log the stats (min, max, q1, q3, etc) to the console.  Useful for copying out to spreadsheet when running the test on Android via chrome remote debugging.
    - Log the raw timing data. (Also useful for statistical testing.)

Didn't change anything else.