### PR TITLE
Add OscillatorNode automation test

### DIFF
--- a/js/Test.js
+++ b/js/Test.js
@@ -346,6 +346,30 @@ class OscillatorTest extends Test {
   }
 }
 
+class OscillatorAutomationTest extends Test {
+  constructor(rampType, automationRate) {
+    super('Oscillator.frequency-' + rampType + '-' + automationRate, 3);
+    this.rampType = rampType;
+    this.automationRate = automationRate;
+  }
+
+  buildGraph(ctx, last) {
+    for (let i = 0; i < this.numNodes; i++) {
+      const node = ctx.createOscillator();
+      node.frequency.automationRate = this.automationRate;
+      node.frequency.setValueAtTime(100, 0);
+      if (this.rampType = "linear") {
+          node.frequency.linearRampToValueAtTime(4000, 1000);
+      } else {
+        throw new Error('Bad rampType: ' + this.rampType);
+      }
+      node.start(0);
+      node.connect(ctx.destination);
+    }
+    return last;
+  }
+}
+
 class AudioBufferSourceTest extends Test {
   constructor(rate, numNodes) {
     super('AudioBufferSource-rate' + rate, numNodes);

--- a/js/Test.js
+++ b/js/Test.js
@@ -358,7 +358,7 @@ class OscillatorAutomationTest extends Test {
       const node = ctx.createOscillator();
       node.frequency.automationRate = this.automationRate;
       node.frequency.setValueAtTime(100, 0);
-      if (this.rampType = "linear") {
+      if (this.rampType == "linear") {
           node.frequency.linearRampToValueAtTime(4000, 1000);
       } else {
         throw new Error('Bad rampType: ' + this.rampType);

--- a/js/WebAudioBenchApplication.js
+++ b/js/WebAudioBenchApplication.js
@@ -112,6 +112,7 @@ class WebAudioBenchApplication {
       new AudioBufferSourceTest(1.0, 20),
       new AudioBufferSourceTest(0.9, 8),
       new OscillatorTest(),
+      new OscillatorAutomationTest('linear', 'a-rate'),
       new GainTest('default', '', 'default'),
       new GainTest(1.0, '', '1.0'),
       new GainTest(0.9, '', '0.9'),

--- a/js/WebAudioBenchApplication.js
+++ b/js/WebAudioBenchApplication.js
@@ -113,6 +113,7 @@ class WebAudioBenchApplication {
       new AudioBufferSourceTest(0.9, 8),
       new OscillatorTest(),
       new OscillatorAutomationTest('linear', 'a-rate'),
+      new OscillatorAutomationTest('linear', 'k-rate'),
       new GainTest('default', '', 'default'),
       new GainTest(1.0, '', '1.0'),
       new GainTest(0.9, '', '0.9'),


### PR DESCRIPTION
Add two test for the Oscillator where we have a linear ramp on the frequency of the Oscillator.  Both a-rate and k-rate automation is tested..

Only supported linear ramps because the others probably don't make much difference in figuring out what's expensive in the oscillator automations.  Only support frequency, but could do detune as well, but I didn't add that.

You may want to check that I constructed the test correctly. I think it's right.  Please let me know.