### PR TITLE
Fix typos in printing stats

### DIFF
--- a/js/WebAudioBenchApplication.js
+++ b/js/WebAudioBenchApplication.js
@@ -246,7 +246,7 @@ class WebAudioBenchApplication {
     const max = durations[durations.length - 1];
 
     console.log('Test ' + name);
-    console.log(`Stats: (${min},${min},{$q1},${median},${q3},${max},${mean},${stddev})`);
+    console.log(`Stats: (${min},${min},${q1},${median},${q3},${max},${1e6 * mean},${1e6 * stddev})`);
     console.log('min ' + min + ' (' + durations + ')');
     console.log('mean = ', mean);
     console.log('stddev = ', stddev);


### PR DESCRIPTION
When printing stats to the console, we had `{$q1}` instead of `${q1}`.

Also we need to scale the mean and stddev values to get the printed log values  in usec, like the other values.