### PR TITLE
Allow specifying a pattern for the tests to be run

### DIFF
--- a/js/WebAudioBenchApplication.js
+++ b/js/WebAudioBenchApplication.js
@@ -23,11 +23,27 @@ class WebAudioBenchApplication {
   constructor() {
     this.testsSelection = document.querySelector('.tests-selection select');
     const tests = this.getTestList();
+
+    const urlParams = new URLSearchParams(window.location.search);
+
+    // Regular expression for matching test names that we want to
+    // select for testing.  Use something like
+    // "localhost/?pattern=Oscillator" if you want to select all
+    // Oscillator tests.
+    let testPattern;
+    if (urlParams.has('pattern')) {
+	testPattern = RegExp(urlParams.get('pattern'));
+    }
+
     tests.forEach((test) => {
       const option = document.createElement('option');
       option.value = test.name;
       option.innerText = test.name;
-      option.selected = true;
+      if (testPattern) {
+	  option.selected = testPattern.test(option.value);
+      } else {
+	  option.selected = true;
+      }
       this.testsSelection.appendChild(option);
     });
 
@@ -47,7 +63,6 @@ class WebAudioBenchApplication {
     }
 
     // Update the runs and duration from the URL, if given
-    let urlParams = new URLSearchParams(window.location.search);
     if (urlParams.has('runs')) {
       runsInputElement.value = urlParams.get('runs');
     }

--- a/js/WebAudioBenchApplication.js
+++ b/js/WebAudioBenchApplication.js
@@ -26,13 +26,13 @@ class WebAudioBenchApplication {
 
     const urlParams = new URLSearchParams(window.location.search);
 
-    // Regular expression for matching test names that we want to
+    // Expression for matching test names that we want to
     // select for testing.  Use something like
     // "localhost/?pattern=Oscillator" if you want to select all
     // Oscillator tests.
     let testPattern;
     if (urlParams.has('pattern')) {
-	testPattern = RegExp(urlParams.get('pattern'));
+	testPattern = urlParams.get('pattern');
     }
 
     tests.forEach((test) => {
@@ -40,7 +40,7 @@ class WebAudioBenchApplication {
       option.value = test.name;
       option.innerText = test.name;
       if (testPattern) {
-	  option.selected = testPattern.test(option.value);
+	  option.selected = option.value.indexOf(testPattern) !== -1;
       } else {
 	  option.selected = true;
       }


### PR DESCRIPTION
When running on Android, it's quite a pain to select a subset of the tests using the selector.  Hence, allow a "pattern" URL query parameter to select which tests to be run.  The key is "pattern" and the value is a regular expression which is used to match the name of the test.  If the name matches, the test is selected.